### PR TITLE
Nouvel URL du projet asciidoctor-diamonded

### DIFF
--- a/outils_externes.md
+++ b/outils_externes.md
@@ -2,4 +2,4 @@
 
 Certains auteurs ont mis à disposition des outils permettant de travailler avec le format Markdown ou Asciidoc:
 * Pour Markdown : [Cyrille Rossant](https://gist.github.com/rossant/99a2316465c84192b630)
-* Pour Asciidoc : [Benoît Benedetti](https://bitbucket.org/humboldtux/glmf-template)
+* Pour Asciidoc : [Benoît Benedetti](https://github.com/humboldtux/asciidoctor-diamonded)


### PR DESCRIPTION
Le projet semble avoir migré, comme l'indique la page derrière le lien actuel : https://bitbucket.org/humboldtux/glmf-template.